### PR TITLE
Add default default octave depending on KK model

### DIFF
--- a/inc/cabl/devices/Device.h
+++ b/inc/cabl/devices/Device.h
@@ -237,6 +237,8 @@ public:
 
   virtual size_t numOfLedArrays() const = 0;
 
+  virtual size_t currentOctave() const { return 0; }
+
   virtual void setButtonLed(Button, const Color&);
 
   virtual void setKeyLed(unsigned, const Color&);

--- a/src/devices/ni/KompleteKontrol.cpp
+++ b/src/devices/ni/KompleteKontrol.cpp
@@ -22,23 +22,6 @@ const uint8_t kKK_ledsDataSize = 25;
 
 const uint8_t kKK_epOut = 0x02;
 const uint8_t kKK_epInput = 0x84;
-
-size_t getInitialOctave(const sl::cabl::KompleteKontrolBase::NUM_KEYS numKeys)
-{
-  using namespace sl::cabl;
-
-  switch (numKeys)
-  {
-    case KompleteKontrolBase::KEYS_25:
-      return 48;
-    case KompleteKontrolBase::KEYS_49:
-    case KompleteKontrolBase::KEYS_61:
-      return 36;
-    default:
-      return 21;
-  }
-}
-
 } // namespace
 
 //--------------------------------------------------------------------------------------------------
@@ -260,13 +243,10 @@ enum class KompleteKontrolBase::Button : uint8_t
 
 //--------------------------------------------------------------------------------------------------
 
-KompleteKontrolBase::KompleteKontrolBase(const NUM_KEYS numKeys)
-  : m_numKeys(static_cast<unsigned>(numKeys))
-  , m_ledsKeysSize(m_numKeys * 3U)
-  , m_ledsKeys(new uint8_t[m_ledsKeysSize])
-  , m_isDirtyLeds(true)
+KompleteKontrolBase::KompleteKontrolBase()
+  : m_isDirtyLeds(true)
   , m_isDirtyKeyLeds(true)
-  , m_firstOctave(getInitialOctave(numKeys))
+  , m_hasValidOctave(false)
 #if defined(_WIN32) || defined(__APPLE__) || defined(__linux)
   , m_pMidiOut(new RtMidiOut)
   , m_pMidiIn(new RtMidiIn)
@@ -332,7 +312,6 @@ KompleteKontrolBase::KompleteKontrolBase(const NUM_KEYS numKeys)
 
 KompleteKontrolBase::~KompleteKontrolBase()
 {
-  delete[] m_ledsKeys;
 #if defined(_WIN32) || defined(__APPLE__) || defined(__linux)
   m_pMidiOut->closePort();
   m_pMidiIn->closePort();
@@ -537,6 +516,7 @@ void KompleteKontrolBase::processButtons(const Transfer& input_)
   }
 
   m_firstOctave = input_.data()[37];
+  m_hasValidOctave = true;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -710,6 +690,38 @@ void KompleteKontrolBase::midiInCallback(
       pMessage_->at(2) / 127.0,
       pSelf->isButtonPressed(Button::Shift));
   }
+}
+
+//--------------------------------------------------------------------------------------------------
+
+template <>
+size_t KompleteKontrolS25::defaultOctave() const
+{
+  return 48;
+}
+
+//--------------------------------------------------------------------------------------------------
+
+template <>
+size_t KompleteKontrolS49::defaultOctave() const
+{
+  return 36;
+}
+
+//--------------------------------------------------------------------------------------------------
+
+template <>
+size_t KompleteKontrolS61::defaultOctave() const
+{
+  return 36;
+}
+
+//--------------------------------------------------------------------------------------------------
+
+template <>
+size_t KompleteKontrolS88::defaultOctave() const
+{
+  return 21;
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/src/devices/ni/KompleteKontrol.cpp
+++ b/src/devices/ni/KompleteKontrol.cpp
@@ -22,6 +22,23 @@ const uint8_t kKK_ledsDataSize = 25;
 
 const uint8_t kKK_epOut = 0x02;
 const uint8_t kKK_epInput = 0x84;
+
+size_t getInitialOctave(const sl::cabl::KompleteKontrolBase::NUM_KEYS numKeys)
+{
+  using namespace sl::cabl;
+
+  switch (numKeys)
+  {
+    case KompleteKontrolBase::KEYS_25:
+      return 48;
+    case KompleteKontrolBase::KEYS_49:
+    case KompleteKontrolBase::KEYS_61:
+      return 36;
+    default:
+      return 21;
+  }
+}
+
 } // namespace
 
 //--------------------------------------------------------------------------------------------------
@@ -243,9 +260,13 @@ enum class KompleteKontrolBase::Button : uint8_t
 
 //--------------------------------------------------------------------------------------------------
 
-KompleteKontrolBase::KompleteKontrolBase()
-  : m_isDirtyLeds(true)
+KompleteKontrolBase::KompleteKontrolBase(const NUM_KEYS numKeys)
+  : m_numKeys(static_cast<unsigned>(numKeys))
+  , m_ledsKeysSize(m_numKeys * 3U)
+  , m_ledsKeys(new uint8_t[m_ledsKeysSize])
+  , m_isDirtyLeds(true)
   , m_isDirtyKeyLeds(true)
+  , m_firstOctave(getInitialOctave(numKeys))
 #if defined(_WIN32) || defined(__APPLE__) || defined(__linux)
   , m_pMidiOut(new RtMidiOut)
   , m_pMidiIn(new RtMidiIn)
@@ -311,6 +332,7 @@ KompleteKontrolBase::KompleteKontrolBase()
 
 KompleteKontrolBase::~KompleteKontrolBase()
 {
+  delete[] m_ledsKeys;
 #if defined(_WIN32) || defined(__APPLE__) || defined(__linux)
   m_pMidiOut->closePort();
   m_pMidiIn->closePort();

--- a/src/devices/ni/KompleteKontrol.h
+++ b/src/devices/ni/KompleteKontrol.h
@@ -26,7 +26,16 @@ class KompleteKontrolBase : public Device
 {
 
 public:
-  KompleteKontrolBase();
+
+  enum NUM_KEYS
+  {
+    KEYS_25 = 25,
+    KEYS_49 = 49,
+    KEYS_61 = 61,
+    KEYS_88 = 88
+  };
+
+  KompleteKontrolBase(NUM_KEYS numKeys);
   ~KompleteKontrolBase() override;
 
   void setButtonLed(Device::Button, const Color&) override;
@@ -35,6 +44,11 @@ public:
   void sendMidiMsg(tRawData) override;
 
   TextDisplay* textDisplay(size_t displayIndex_) override;
+
+  unsigned numKeys() const
+  {
+    return m_numKeys;
+  }
 
   size_t numOfGraphicDisplays() const override
   {
@@ -54,6 +68,21 @@ public:
   size_t numOfLedArrays() const override
   {
     return 0;
+  }
+
+  size_t currentOctave() const override
+  {
+    return m_firstOctave;
+  }
+
+  unsigned ledDataSize() const
+  {
+    return m_ledsKeysSize;
+  }
+
+  uint8_t* ledsKeysData()
+  {
+    return &m_ledsKeys[0];
   }
 
   bool tick() override;
@@ -83,17 +112,16 @@ private:
   bool isButtonPressed(Button button) const noexcept;
   bool isButtonPressed(const Transfer&, Button button_) const noexcept;
 
-  virtual unsigned numKeys() const = 0;
-  virtual unsigned ledDataSize() const = 0;
-  virtual uint8_t* ledsKeysData() = 0;
-
   static void midiInCallback(double timeStamp, std::vector<unsigned char>* message, void* userData);
 
   NullCanvas m_displayDummy;
   tRawData m_leds;
   tRawData m_buttons;
   std::bitset<kKK_nButtons> m_buttonStates;
+  unsigned m_numKeys;
   unsigned m_encoderValues[kKK_nEncoders];
+  unsigned m_ledsKeysSize;
+  uint8_t* m_ledsKeys;
 
   bool m_isDirtyLeds;
   bool m_isDirtyKeyLeds;
@@ -110,36 +138,29 @@ private:
 
 //--------------------------------------------------------------------------------------------------
 
-template <uint8_t NKEYS>
-class KompleteKontrol final : public KompleteKontrolBase
+class KompleteKontrolS25 final : public KompleteKontrolBase
 {
 public:
-  static constexpr unsigned kKK_keysLedDataSize = NKEYS * 3U;
-
-  unsigned numKeys() const override
-  {
-    return NKEYS;
-  }
-  unsigned ledDataSize() const override
-  {
-    return kKK_keysLedDataSize;
-  }
-
-private:
-  uint8_t* ledsKeysData() override
-  {
-    return &m_ledsKeys[0];
-  }
-
-  uint8_t m_ledsKeys[kKK_keysLedDataSize];
+  KompleteKontrolS25() : KompleteKontrolBase(KEYS_25) {}
 };
 
-//--------------------------------------------------------------------------------------------------
+class KompleteKontrolS49 final : public KompleteKontrolBase
+{
+public:
+  KompleteKontrolS49() : KompleteKontrolBase(KEYS_49) {}
+};
 
-using KompleteKontrolS25 = KompleteKontrol<25>;
-using KompleteKontrolS49 = KompleteKontrol<49>;
-using KompleteKontrolS61 = KompleteKontrol<61>;
-using KompleteKontrolS88 = KompleteKontrol<88>;
+class KompleteKontrolS61 final : public KompleteKontrolBase
+{
+public:
+  KompleteKontrolS61() : KompleteKontrolBase(KEYS_61) {}
+};
+
+class KompleteKontrolS88 final : public KompleteKontrolBase
+{
+public:
+  KompleteKontrolS88() : KompleteKontrolBase(KEYS_88) {}
+};
 
 //--------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Removes the concept of templated KKS1 child class. The number of keys is an argument of the base class
This is done in order to initialize the `m_firstOctave` to the default keyboard value depending (which depends on the size)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shaduzlabs/cabl/12)
<!-- Reviewable:end -->
