### PR TITLE
MK1 Bugfix

### DIFF
--- a/cmake/FindRtMidi.cmake
+++ b/cmake/FindRtMidi.cmake
@@ -1,8 +1,10 @@
 
 message (STATUS "Checking for RtMidi...")
 find_path(RTMIDI_INCLUDE_DIRS RtMidi.h
-  /usr/local/include
-  /usr/include
+  PATHS
+    /usr/local/include
+    /usr/include
+    /usr/include/rtmidi
   HINTS /tmp/rtmidi-2.1.0 # for travis-ci linux build
 )
 

--- a/inc/cabl/comm/Transfer.h
+++ b/inc/cabl/comm/Transfer.h
@@ -64,6 +64,8 @@ public:
     return m_data.size();
   }
 
+  std::string toString() const;
+
 private:
 #ifdef CABL_USE_NETWORK
   friend class cereal::access;

--- a/src/comm/Transfer.cpp
+++ b/src/comm/Transfer.cpp
@@ -80,5 +80,22 @@ void Transfer::setData(const uint8_t* data_, size_t length_)
 
 //--------------------------------------------------------------------------------------------------
 
+std::string Transfer::toString() const
+{
+  static const char * HEX_DIGIT = "0123456789ABCDEF";
+
+  std::string result;
+
+  for ( uint8_t byte : m_data )
+  {
+    result += HEX_DIGIT[ (byte>>4) & 0xF ];
+    result += HEX_DIGIT[ byte & 0xF ];
+    result += '|';
+  }
+
+  return result;
+}
+
+
 } // namespace cabl
 } // namespace sl

--- a/src/devices/ni/MaschineMK1.cpp
+++ b/src/devices/ni/MaschineMK1.cpp
@@ -60,7 +60,7 @@ enum class MaschineMK1::Led : uint8_t
   Select,
   Duplicate,
   Navigate,
-  Keyboard,
+  PadMode,
   Pattern,
   Scene,
   Shift,
@@ -113,7 +113,7 @@ enum class MaschineMK1::Button : uint8_t
   Select,
   Duplicate,
   Navigate,
-  Keyboard,
+  PadMode,
   Pattern,
   Scene,
 
@@ -406,7 +406,11 @@ bool MaschineMK1::read()
     M_LOG("[MaschineMK1] read: ERROR");
     return false;
   }
-  processPads(input);
+
+  if (input[0] != 2) // Strange but I had to add this filter to avoid strange pad updates when turning encoders.
+  {
+    processPads(input);
+  }
   return true;
 }
 
@@ -417,7 +421,7 @@ void MaschineMK1::processPads(const Transfer& input_)
   for (int i = 1; i < kMASMK1_padDataSize - 1; i += 2)
   {
     unsigned h = input_[i];
-    unsigned l = input_[i + 1];
+    unsigned l = input_[i - 1];
     uint8_t pad = (h & 0xF0) >> 4;
 
     m_padsData[pad] = (((h & 0x0F) << 8) | l);
@@ -426,7 +430,7 @@ void MaschineMK1::processPads(const Transfer& input_)
     {
       m_padsStatus[pad] = true;
       keyChanged(
-        pad, m_padsData[pad] / 1024.0, m_buttonStates[static_cast<uint8_t>(Button::Shift)]);
+        pad, m_padsData[pad] / 4096.0 , m_buttonStates[static_cast<uint8_t>(Button::Shift)]);
     }
     else
     {
@@ -577,7 +581,7 @@ MaschineMK1::Led MaschineMK1::led(Device::Button btn_) const noexcept
     M_LED_CASE(Select);
     M_LED_CASE(Duplicate);
     M_LED_CASE(Navigate);
-    M_LED_CASE(Keyboard);
+    M_LED_CASE(PadMode);
     M_LED_CASE(Pattern);
     M_LED_CASE(Scene);
     M_LED_CASE(Shift);
@@ -671,7 +675,7 @@ Device::Button MaschineMK1::deviceButton(Button btn_) const noexcept
     M_BTN_CASE(Select);
     M_BTN_CASE(Duplicate);
     M_BTN_CASE(Navigate);
-    M_BTN_CASE(Keyboard);
+    M_BTN_CASE(PadMode);
     M_BTN_CASE(Pattern);
     M_BTN_CASE(Scene);
     M_BTN_CASE(Rec);

--- a/src/devices/ni/MaschineMK1.h
+++ b/src/devices/ni/MaschineMK1.h
@@ -11,7 +11,6 @@
 
 #include "cabl/comm/Transfer.h"
 #include "cabl/devices/Device.h"
-#include "cabl/devices/DeviceFactory.h"
 #include "gfx/displays/GDisplayMaschineMK1.h"
 
 namespace sl


### PR DESCRIPTION
Hello,

I started to test cabl with my MK1 and I notices some issues I fixed:
* Turning encoders used to trigger some `keyChanged` event, I added a test to filter them
* hitting a pad used to the imply some glitchy `keyChanged` event on the pad next to it.
* cmake could not find my rtmidi path

The others changes are minor:
* a `Transfert::toString` method to help debugging
* a useless include dependency
* a button renamed (no Keyboard button on MK1 device)

Thank you

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shaduzlabs/cabl/14)
<!-- Reviewable:end -->
