### PR TITLE
Support of MaschineMk1 MIDI ports

### DIFF
--- a/src/devices/ni/MaschineMK1.h
+++ b/src/devices/ni/MaschineMK1.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <bitset>
+#include <deque>
 
 #include "cabl/comm/Transfer.h"
 #include "cabl/devices/Device.h"
@@ -76,6 +77,7 @@ private:
   bool sendFrame(uint8_t displayIndex_);
   bool sendLeds();
   bool read();
+  bool writeMidiMsg();
 
   void processPads(const Transfer&);
   void processButtons(const Transfer&);
@@ -105,6 +107,9 @@ private:
   bool m_isDirtyLedGroup0{true};
   bool m_isDirtyLedGroup1{true};
   bool m_encodersInitialized{false};
+
+  std::deque<tRawData> m_MidiOutQueue;
+
 };
 
 //--------------------------------------------------------------------------------------------------

--- a/src/devices/ni/MaschineMK1.h
+++ b/src/devices/ni/MaschineMK1.h
@@ -82,6 +82,7 @@ private:
   void processPads(const Transfer&);
   void processButtons(const Transfer&);
   void processEncoders(const Transfer&);
+  void processMidiIn(const Transfer&);
 
   void setLedImpl(Led, const Color&);
   Led led(Device::Button) const noexcept;
@@ -109,7 +110,9 @@ private:
   bool m_encodersInitialized{false};
 
   std::deque<tRawData> m_MidiOutQueue;
+  std::deque<uint8_t> m_MidiInBuffer;
 
+  std::unique_ptr<RtMidiOut> m_pVirtualMidiIn;
 };
 
 //--------------------------------------------------------------------------------------------------

--- a/src/devices/ni/MaschineMK1.h
+++ b/src/devices/ni/MaschineMK1.h
@@ -77,6 +77,8 @@ private:
   bool sendFrame(uint8_t displayIndex_);
   bool sendLeds();
   bool read();
+
+  bool getNextMidiOutMsg(tRawData & midiMsg_);
   bool writeMidiMsg();
 
   void processPads(const Transfer&);
@@ -113,6 +115,7 @@ private:
   std::deque<uint8_t> m_MidiInBuffer;
 
   std::unique_ptr<RtMidiOut> m_pVirtualMidiIn;
+  std::unique_ptr<RtMidiIn> m_pVirtualMidiOut;
 };
 
 //--------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Hello,

Here are developments I needed to access MIDI ports of my MaschineMk1.

* Messages sent to MIDI OUT port are now enqueued (otherwise I had a deadlock when sending midi from controller callbacks)
* MIDI IN port decoding (forwarded to virtual port)
* MIDI OUT port can also be populated throw a virtual port.

Any comment welcome

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shaduzlabs/cabl/18)
<!-- Reviewable:end -->
